### PR TITLE
Fix duplicate route mapping

### DIFF
--- a/GununSozu.Web/Program.cs
+++ b/GununSozu.Web/Program.cs
@@ -32,10 +32,6 @@ app.UseAuthorization();
 
 
 app.MapControllerRoute(
-    name: "default",
-    pattern: "{controller=Home}/{action=Index}/{id?}");
-
-app.MapControllerRoute(
     name: "areas",
     pattern: "{area:exists}/{controller=Home}/{action=Index}/{id?}");
 


### PR DESCRIPTION
## Summary
- clean up duplicate MapControllerRoute definition in the web project's Program.cs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68807ad4bdd48326abe55c5ddc23de72