### PR TITLE
Use Guid keys and enum-based roles

### DIFF
--- a/GununSozu.Api/Controllers/AuthController.cs
+++ b/GununSozu.Api/Controllers/AuthController.cs
@@ -4,6 +4,8 @@ using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using GununSozu.Data.Models;
+using System;
 
 namespace GununSozu.Api.Controllers;
 
@@ -11,10 +13,10 @@ namespace GununSozu.Api.Controllers;
 [Route("api/[controller]")]
 public class AuthController : ControllerBase
 {
-    private readonly UserManager<IdentityUser> _userManager;
+    private readonly UserManager<ApplicationUser> _userManager;
     private readonly IConfiguration _configuration;
 
-    public AuthController(UserManager<IdentityUser> userManager, IConfiguration configuration)
+    public AuthController(UserManager<ApplicationUser> userManager, IConfiguration configuration)
     {
         _userManager = userManager;
         _configuration = configuration;
@@ -32,6 +34,7 @@ public class AuthController : ControllerBase
             {
                 Subject = new ClaimsIdentity(new[]
                 {
+                    new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
                     new Claim(ClaimTypes.Name, user.UserName!)
                 }),
                 Expires = DateTime.UtcNow.AddHours(1),

--- a/GununSozu.Api/Controllers/QuoteController.cs
+++ b/GununSozu.Api/Controllers/QuoteController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System;
 using GununSozu.Business.DTOs;
 using GununSozu.Data.Models;
 using System.Security.Claims;
@@ -64,11 +65,11 @@ namespace GununSozu.Api.Controllers
                 return BadRequest("Eksik bilgi.");
 
             // JWT içerisinden UserId alın (NameIdentifier ya da sub claim)
-            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var userIdValue = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
-            if (!Guid.TryParse(userIdClaim, out var userId))
+            if (string.IsNullOrEmpty(userIdValue) || !Guid.TryParse(userIdValue, out var userId))
                 return Unauthorized();
-            
+
             var _quoteService = new QuoteService(_context);
             await _quoteService.SetFavoriteAsync(userId, dto);
             return NoContent();

--- a/GununSozu.Api/Program.cs
+++ b/GununSozu.Api/Program.cs
@@ -13,7 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<GununSozuDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-builder.Services.AddIdentity<IdentityUser, IdentityRole>()
+builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
     .AddEntityFrameworkStores<GununSozuDbContext>()
     .AddDefaultTokenProviders();
 

--- a/GununSozu.Business/Interfaces/IQuoteService.cs
+++ b/GununSozu.Business/Interfaces/IQuoteService.cs
@@ -1,5 +1,6 @@
 ﻿using GununSozu.Business.DTOs;
 using GununSozu.Data.Models;
+using System;
 
 namespace GununSozu.Business.Interfaces
 {

--- a/GununSozu.Business/Services/QuoteService.cs
+++ b/GununSozu.Business/Services/QuoteService.cs
@@ -2,6 +2,7 @@
 using GununSozu.Business.Interfaces;
 using GununSozu.Data.Models;
 using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace GununSozu.Business.Services
 {
@@ -74,7 +75,7 @@ namespace GununSozu.Business.Services
         public async Task SetFavoriteAsync(Guid userId, SetFavoriteDto dto)
         {
             // Kullanıcının varlığını doğrula
-            var user = await _context.USR_Users
+            var user = await _context.Users
                 .FirstOrDefaultAsync(u => u.Id == userId);
 
             if (user == null)

--- a/GununSozu.Data/Models/AppRoles.cs
+++ b/GununSozu.Data/Models/AppRoles.cs
@@ -1,0 +1,9 @@
+namespace GununSozu.Data.Models
+{
+    public enum AppRoles
+    {
+        User = 1,
+        Admin = 2,
+        GM = 3
+    }
+}

--- a/GununSozu.Data/Models/ApplicationUser.cs
+++ b/GununSozu.Data/Models/ApplicationUser.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Identity;
 
 namespace GununSozu.Data.Models
 {
-    public class USR_Users
+    public class ApplicationUser : IdentityUser<Guid>
     {
-        [Key]
-        public Guid Id { get; set; } = Guid.NewGuid();
-
+        public override Guid Id { get; set; } = Guid.NewGuid();
         public string DeviceId { get; set; }
 
         [ForeignKey(nameof(Language))]
@@ -19,6 +18,5 @@ namespace GununSozu.Data.Models
         public virtual ICollection<USR_Favorites> Favorites { get; set; }
         public virtual ICollection<USR_Deliveries> Deliveries { get; set; }
         public virtual SYS_Language Language { get; set; }
-
     }
 }

--- a/GununSozu.Data/Models/GununSozuDbContext.cs
+++ b/GununSozu.Data/Models/GununSozuDbContext.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GununSozu.Data.Models;
 
-public partial class GununSozuDbContext : IdentityDbContext<IdentityUser>
+public partial class GununSozuDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
 {
     public GununSozuDbContext(DbContextOptions<GununSozuDbContext> options)
         : base(options)
@@ -15,7 +15,6 @@ public partial class GununSozuDbContext : IdentityDbContext<IdentityUser>
     public virtual DbSet<QTE_Categories> QTE_Categories { get; set; }
     public virtual DbSet<SYS_Language> SYS_Language { get; set; }
 
-    public virtual DbSet<USR_Users> USR_Users { get; set; }
     public virtual DbSet<USR_Preferences> USR_Preferences { get; set; }
     public virtual DbSet<USR_Favorites> USR_Favorites { get; set; }
     public virtual DbSet<USR_Deliveries> USR_Deliveries { get; set; }
@@ -28,7 +27,6 @@ public partial class GununSozuDbContext : IdentityDbContext<IdentityUser>
         modelBuilder.Entity<QTE_Categories>().ToTable("QTE_Categories");
         modelBuilder.Entity<SYS_Language>().ToTable("SYS_Language");
 
-        modelBuilder.Entity<USR_Users>().ToTable("USR_Users");
         modelBuilder.Entity<USR_Preferences>().ToTable("USR_Preferences");
 
         modelBuilder.Entity<USR_Favorites>()

--- a/GununSozu.Data/Models/USR_Deliveries.cs
+++ b/GununSozu.Data/Models/USR_Deliveries.cs
@@ -7,7 +7,7 @@ namespace GununSozu.Data.Models
     public class USR_Deliveries
     {
         [Key]
-        public int Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
         [ForeignKey(nameof(User))]
         public Guid UserId { get; set; }
@@ -20,7 +20,7 @@ namespace GununSozu.Data.Models
         public bool WasLiked { get; set; }
 
         // Navigation
-        public virtual USR_Users User { get; set; }
+        public virtual ApplicationUser User { get; set; }
         public virtual QTE_Quotes Quote { get; set; }
     }
 }

--- a/GununSozu.Data/Models/USR_Favorites.cs
+++ b/GununSozu.Data/Models/USR_Favorites.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GununSozu.Data.Models
@@ -16,7 +17,7 @@ namespace GununSozu.Data.Models
 
         public bool? IsLiked { get; set; }
         // Navigation
-        public virtual USR_Users User { get; set; }
+        public virtual ApplicationUser User { get; set; }
         public virtual QTE_Quotes Quote { get; set; }
     }
 }

--- a/GununSozu.Data/Models/USR_Preferences.cs
+++ b/GununSozu.Data/Models/USR_Preferences.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GununSozu.Data.Models
@@ -17,6 +18,6 @@ namespace GununSozu.Data.Models
         public int PreferredCategory { get; set; }
 
         // Navigation
-        public virtual USR_Users User { get; set; }
+        public virtual ApplicationUser User { get; set; }
     }
 }

--- a/GununSozu.Data/Seed/SeedData.cs
+++ b/GununSozu.Data/Seed/SeedData.cs
@@ -1,6 +1,7 @@
 ﻿using GununSozu.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Identity;
 using System;
 using System.Linq;
 
@@ -13,9 +14,6 @@ namespace GununSozu.Data.Seed
             using var context = new GununSozuDbContext(
                 serviceProvider.GetRequiredService<DbContextOptions<GununSozuDbContext>>());
 
-            if (context.QTE_Quotes.Any())
-                return; // Daha önce seed yapılmış
-
             // Id'leri önceden belirleyerek ilişkileri düzgün kur
             var languageTrId = Guid.NewGuid();
             var languageEnId = Guid.NewGuid();
@@ -24,38 +22,79 @@ namespace GununSozu.Data.Seed
             var categoryGeneralId = Guid.NewGuid();
 
             // DİLLER
-            var languageTr = new SYS_Language { Id = languageTrId, Name = "Türkçe" };
-            var languageEn = new SYS_Language { Id = languageEnId, Name = "English" };
-            context.SYS_Language.AddRange(languageTr, languageEn);
+            if (!context.SYS_Language.Any())
+            {
+                var languageTr = new SYS_Language { Id = languageTrId, Name = "Türkçe" };
+                var languageEn = new SYS_Language { Id = languageEnId, Name = "English" };
+                context.SYS_Language.AddRange(languageTr, languageEn);
+            }
 
             // KATEGORİLER
-            var category1 = new QTE_Categories { Id = categoryMotivationId, Name = "Motivasyon", Description = "İlham verici sözler" };
-            var category2 = new QTE_Categories { Id = categoryGeneralId, Name = "Genel", Description = "Genel sözler" };
-            context.QTE_Categories.AddRange(category1, category2);
+            if (!context.QTE_Categories.Any())
+            {
+                var category1 = new QTE_Categories { Id = categoryMotivationId, Name = "Motivasyon", Description = "İlham verici sözler" };
+                var category2 = new QTE_Categories { Id = categoryGeneralId, Name = "Genel", Description = "Genel sözler" };
+                context.QTE_Categories.AddRange(category1, category2);
+            }
 
             // SÖZLER
-            context.QTE_Quotes.AddRange(
-                new QTE_Quotes
-                {
-                    Id = Guid.NewGuid(),
-                    Content = "Başlamak için mükemmel olmak zorunda değilsin, ama mükemmel olmak için başlamak zorundasın.",
-                    Author = "Zig Ziglar",
-                    CategoryId = categoryMotivationId,
-                    LanguageId = languageTrId,
-                    IsActive = true
-                },
-                new QTE_Quotes
-                {
-                    Id = Guid.NewGuid(),
-                    Content = "Don’t watch the clock; do what it does. Keep going.",
-                    Author = "Sam Levenson",
-                    CategoryId = categoryMotivationId,
-                    LanguageId = languageEnId,
-                    IsActive = true
-                }
-            );
+            if (!context.QTE_Quotes.Any())
+            {
+                context.QTE_Quotes.AddRange(
+                    new QTE_Quotes
+                    {
+                        Id = Guid.NewGuid(),
+                        Content = "Başlamak için mükemmel olmak zorunda değilsin, ama mükemmel olmak için başlamak zorundasın.",
+                        Author = "Zig Ziglar",
+                        CategoryId = categoryMotivationId,
+                        LanguageId = languageTrId,
+                        IsActive = true
+                    },
+                    new QTE_Quotes
+                    {
+                        Id = Guid.NewGuid(),
+                        Content = "Don’t watch the clock; do what it does. Keep going.",
+                        Author = "Sam Levenson",
+                        CategoryId = categoryMotivationId,
+                        LanguageId = languageEnId,
+                        IsActive = true
+                    }
+                );
+            }
 
             context.SaveChanges();
+
+            var userManager = serviceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
+
+            foreach (AppRoles role in Enum.GetValues(typeof(AppRoles)))
+            {
+                var roleName = role.ToString();
+                if (!roleManager.Roles.Any(r => r.Name == roleName))
+                {
+                    roleManager.CreateAsync(new IdentityRole<Guid>
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = roleName,
+                        NormalizedName = roleName.ToUpper()
+                    }).Wait();
+                }
+            }
+
+            // ADMIN USER
+            const string adminUserName = "admin";
+            if (!userManager.Users.Any(u => u.UserName == adminUserName))
+            {
+                var admin = new ApplicationUser
+                {
+                    UserName = adminUserName,
+                    Email = "admin@example.com",
+                    DeviceId = "default-device",
+                    LanguageId = languageTrId
+                };
+                userManager.CreateAsync(admin, "Admin123!").Wait();
+                userManager.AddToRoleAsync(admin, AppRoles.Admin.ToString()).Wait();
+            }
         }
     }
 }

--- a/GununSozu.Web/Controllers/AccountController.cs
+++ b/GununSozu.Web/Controllers/AccountController.cs
@@ -1,14 +1,15 @@
 using GununSozu.Web.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using GununSozu.Data.Models;
 
 namespace GununSozu.Web.Controllers;
 
 public class AccountController : Controller
 {
-    private readonly SignInManager<IdentityUser> _signInManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
 
-    public AccountController(SignInManager<IdentityUser> signInManager)
+    public AccountController(SignInManager<ApplicationUser> signInManager)
     {
         _signInManager = signInManager;
     }

--- a/GununSozu.Web/Program.cs
+++ b/GununSozu.Web/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddScoped<IQuoteService, QuoteService>();
 builder.Services.AddDbContext<GununSozuDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-builder.Services.AddIdentity<IdentityUser, IdentityRole>()
+builder.Services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()
     .AddEntityFrameworkStores<GununSozuDbContext>()
     .AddDefaultTokenProviders();
 


### PR DESCRIPTION
## Summary
- switch identity and related tables to Guid primary keys
- seed enum-based roles (User, Admin, GM) with default admin user
- update services and controllers to work with Guid user IDs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d204392f48326a82e202177fe6423